### PR TITLE
#75 Adjust Paginator width

### DIFF
--- a/cardDatabase/views.py
+++ b/cardDatabase/views.py
@@ -296,7 +296,7 @@ def search_for_cards(request):
     if 'cards' in ctx:
         paginator = Paginator(ctx['cards'], request.GET.get('num_per_page', 30))
         page_number = request.GET.get('page', 1)
-        ctx['page_range'] = paginator.get_elided_page_range(number=page_number)
+        ctx['page_range'] = paginator.get_elided_page_range(number=page_number, on_each_side=1, on_ends=1)
         ctx['total_count'] = len(ctx['cards'])
         ctx['cards'] = paginator.get_page(page_number)
     return render(request, 'cardDatabase/html/search.html', context=ctx)


### PR DESCRIPTION
Paginator default options changed:
page: 10

**Before**
on_each_side=3, on_ends=2
[1, 2, '…', 7, 8, 9, 10, 11, 12, 13, '…', 49, 50] 

**NOW**
on_each_side=1, on_ends=1
[1, '…', 9, 10, 11, '…', 50]
to decrease the width, while keeping a good overview over no. of max/min and next/previous page.   