### PR TITLE
#94 Add Union Seven Machine/Olymps to keyword search

### DIFF
--- a/fowsim/constants.py
+++ b/fowsim/constants.py
@@ -687,7 +687,9 @@ KEYWORDS_CHOICES = [
     ('[Force Command]', 'Force Command'),
     ('[Force Resonance]', 'Force Resonance'),
     ('[Dragon Emblem]', 'Dragon Emblem'),
-    ('[Force]', 'Force')
+    ('[Force]', 'Force'),
+    ('[Union Seven <Machine>]', 'Union Seven <Machine>'),
+    ('[Union Seven <New Twelve Olympian Gods>]', 'Union Seven <New Twelve Olympian Gods>')
 ]
 
 


### PR DESCRIPTION
Added [Union Seven <New Twelve Olympian Gods>] and [Union Seven <Machine>]  to searchable keywords