### PR TITLE
Feature: #17 using overflow css styling to adjust total cost on mobile

### DIFF
--- a/cardDatabase/static/css/database_base_mobile.css
+++ b/cardDatabase/static/css/database_base_mobile.css
@@ -32,3 +32,10 @@
     width: calc(100% - 40px);
     max-width: calc(100% - 40px);
 }
+
+.overflow-costs {
+    width: 80vw;
+    overflow: auto;
+    white-space: nowrap;
+    display: inline-block;
+}

--- a/cardDatabase/templates/cardDatabase/html/database_base.html
+++ b/cardDatabase/templates/cardDatabase/html/database_base.html
@@ -124,6 +124,7 @@
                         <div class="search-field-title field-title">
                             Total cost:
                         </div>
+                        <div class="overflow-costs">
                         {% for value, display in advanced_form.cost.field.choices %}
                             <input type="checkbox" class="hidden-checkbox fow-checkbox" name="cost" id="id_cost_{{ forloop.counter0 }}"
                                    value="{{ value }}" {% if value|slugify in advanced_form_data.cost %}checked{% endif %}>
@@ -133,6 +134,7 @@
                                 </div>
                             </label>
                         {% endfor %}
+                        </div>
                     </div>
                     <div class="fieldWrapper race-select">
                         <select class="mdb-select md-form" multiple form="advanced-form" name="race" searchable="Search here...">


### PR DESCRIPTION
#17 Overflow css styling is used for the total costs when on mobile / smaller screens.  I did not implement the plus sign, but what I have might do the job (users can just slide to find the cost they want to input?)