### PR TITLE
#114 setting select-dropdown inputs to z-index auto to fix appearing …

### DIFF
--- a/cardDatabase/static/css/database_base.css
+++ b/cardDatabase/static/css/database_base.css
@@ -250,3 +250,8 @@ input:checked + .selected-backgrounds{
 .tooltip-values > div{
     flex: 0 0 50%;
 }
+
+/* ensure select-dropdowns appear behind card image popout when edit deck list and on adv search page  */
+input.select-dropdown.form-control{
+    z-index: auto;
+}


### PR DESCRIPTION
#114 setting the select-dropdown css to have a z-index: auto should fix the issue.
So now on the adv search page, when editing a deck list, if you hover over a card name and the card image appears, the border-bottom on the select-dropdown will appear behind the image and still retain it's original functionality.