### PR TITLE
#28 - clear all button to reset advanced search field to default values

### DIFF
--- a/cardDatabase/static/js/database_base.js
+++ b/cardDatabase/static/js/database_base.js
@@ -130,6 +130,11 @@ function initDatabaseBase(){
         $('.help-tooltip.show').removeClass('show');
         $('.tooltip-popup').off('click', checkIfCloseTooltip);
     }
+
+    // clear all text/radio/select inputs from the advance search form
+    $('#clear-advanced-search').on('click', function(event){
+        document.getElementById("advanced-form").reset();
+    });
 }
 $(function(){
     initDatabaseBase();

--- a/cardDatabase/templates/cardDatabase/html/database_base.html
+++ b/cardDatabase/templates/cardDatabase/html/database_base.html
@@ -245,6 +245,7 @@
                     </div>
                     <div class="form-submit-button">
                         <input type="submit" value="Search" name="advanced-form">
+                        <input id="clear-advanced-search" type="button" value="Clear All" name="clear-form">
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
#28 - Input button placed next to search button on advanced search page.  Javascript code added to database_base.js file that targets the #id tag - advanced-form, calling the reset() function on it, which resets the entire form to their default values.