### PR TITLE
#46 initial code for viewing next and previous cards

### DIFF
--- a/cardDatabase/templates/cardDatabase/html/view_card.html
+++ b/cardDatabase/templates/cardDatabase/html/view_card.html
@@ -27,6 +27,23 @@
 {% block body %}
     {{ block.super }}
     <div id="view-card-container">
+        {# Show left/right arrows to navigate to prev/next cards #}
+        {% if prev_card or next_card %}
+            <div class="card-container" style="display: flex;">
+                {# if prev_card is not null, then display the url left to go to next card number #}
+                {% if prev_card %}
+                <div class="card-text-info-text" style="margin-right: auto; margin-left: 0">
+                    <a href="{% url 'cardDatabase-view-card' prev_card.card_id %}">< {{prev_card.card_id}}</a>
+                </div>
+                {% endif %}
+                {# if next_card is not null, then display the url left to go to next card number #}
+                {% if next_card %}
+                <div class="card-text-info-text" style="margin-left: auto; margin-right: 0;">
+                    <a href="{% url 'cardDatabase-view-card' card_id=next_card.card_id %}">{{next_card.card_id}} ></a>
+                </div>
+                {% endif %}
+            </div>
+        {% endif %}
         {% if card.other_sides %}
             {% include 'cardDatabase/html/card_details.html' with referred_by=card|card_referenced_by card=card %}
         {% else %}


### PR DESCRIPTION
@Enhaloed @Kossetsoup #46 

The view_card method in views.py has additional ctx attributes 'prev_card' and 'next_card'.

A new method, get_next_prev_card() takes the current card_id and set code, and sanitize the card number to strip it of the set code and 'J'  if it exists

so "EDL-029" becomes 29
"EDL-031J" becomes 31

Another method, set_next_card_id() accepts the new card int, a vary_by_in argument (this either +1/-1 on the card_int value, the current set_code and an optional int which adds preceding zeros to a card number.  At the moment, this value is ALWAYS 3 and 'should' work for all cards apart from promos.

so e.g.
if we pass in 29, we expect it output EDL-030, if we pass in 4, we expect EDL-004

In the set_next_card_id() method, we essentially create our new card numbers, and check if they exists first of all.  if they do, we create the card data and pass them to the prev_card or next_card attributes in views.py and then pass them to the view_card.html.

If they don't exists however, we know that we either have a card number of 000 (EDL-000), in which case we check CONS.SET_CHOICES for the prev set, and build a new card number and card off of that.

NOTE - atm, I default immediate to the 1st card in the previous set.  Haven't gotten around to figuring out the number of a cards in a set, and then setting the card number to the len() of that set.

We would then repeat for the next_card.