### PR TITLE
add a check to see if the system theme changed

### DIFF
--- a/cardDatabase/static/js/darkmode/dark_mode_toggle.js
+++ b/cardDatabase/static/js/darkmode/dark_mode_toggle.js
@@ -3,11 +3,12 @@ darkModeButton.on('click', toggleButton);
 
 function readThemeCookie() {
     let value = $.cookie('theme');
+    let previousSystemPreference = $.cookie('browserPreferredTheme');
+    let preferredTheme = getBrowserPreferredTheme();
 
     // If the cookie is undefined, then default it to the browser's preferred theme.
     // If the browser has no preference, the default is light.
-    if (!value) {    
-        let preferredTheme = getBrowserPreferredTheme();
+    if (!value || previousSystemPreference != preferredTheme) {
         if (preferredTheme == 'dark') {
             value = 'dark';
         }
@@ -22,6 +23,7 @@ function readThemeCookie() {
 
 function setThemeCookie(theme) {
     $.cookie('theme', theme, { path: '/' });
+    $.cookie('browserPreferredTheme', getBrowserPreferredTheme(), { path: '/' });
 }
 
 function getBrowserPreferredTheme() {


### PR DESCRIPTION
Adds a check to see if the user's browser's preferred theme has changed and will cause the page to update based on that.

If you manually choose a theme without changing your browser's theme it won't change back to your browser's theme