### PR TITLE
Feature/139 deck statistics

### DIFF
--- a/cardDatabase/static/css/view_decklist.css
+++ b/cardDatabase/static/css/view_decklist.css
@@ -200,3 +200,17 @@
 .ban-text, .banned-icon{
     min-width: 0;
 }
+.statistics-attribute-img{
+    width: 40px;
+    height: 40px;
+    border: 1px solid black;
+    border-radius: 20px;
+}
+
+.attribute-wrapper{
+    opacity: 1;
+}
+
+.attribute-wrapper-disabled{
+    opacity: 0.4;
+}

--- a/cardDatabase/static/css/view_decklist_mobile.css
+++ b/cardDatabase/static/css/view_decklist_mobile.css
@@ -26,3 +26,7 @@
     display: block;
     text-align: center;
 }
+
+.attribute-wrapper-disabled{
+    display: none;
+}

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -51,8 +51,6 @@ function calculateDiagramData(cardsToCalc, attributeCanvas, manaCurveCanvas) {
 
     attributeStatData.sort((a, b) => b.count - a.count);
     attributeStatData.forEach((attribute) => {
-        console.log('calc');        
-        console.log(`${attribute.count} = ${attribute.count} * 100 / ${fullAttributeCount}`);
         attribute.count = Math.round(attribute.count * 100 / (fullAttributeCount));
     });
 

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -82,7 +82,7 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
                     },
                     datalabels:{
                         formatter: function(value, _) {
-                            if(value <= 0)
+                            if(value <= 0 || isNaN(value))
                                 return '';
                             else if(value < 5 && mobile)
                                 return value;

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -1,6 +1,6 @@
 const attributeRegex = /\{(\w)\}+/g;
 
-function calculateDiagramData(cardsToCalc, attributeCanvas, manaCurveCanvas) {
+function calculateDiagramData(cardsToCalc, attributeCanvas, manaCurveCanvas, mobile) {
     let manaCurveThreshhold = 6;
     manaCurveStatData = [
         { cost: '0', count: 0 },
@@ -54,10 +54,10 @@ function calculateDiagramData(cardsToCalc, attributeCanvas, manaCurveCanvas) {
         attribute.count = Math.round(attribute.count * 100 / (fullAttributeCount));
     });
 
-    drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCurveStatData);
+    drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCurveStatData, mobile);
 }
 
-function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCurveStatData) {
+function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCurveStatData, mobile) {
     new Chart(attributeCanvas,
         {
             type: 'bar',
@@ -81,8 +81,15 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
                         text: 'Card attributes in %'
                     },
                     datalabels:{
-                        formatter: function(value, context) {
-                            return value + ' %';
+                        formatter: function(value, _) {
+                            if(value <= 0)
+                                return '';
+                            else if(value < 5 && mobile)
+                                return value;
+                            else if(value <= 1)
+                                return value;
+                            else
+                                return value + ' %';
                           }
                     }
                 },
@@ -150,6 +157,6 @@ function isNumeric(str) {
         !isNaN(parseFloat(str))
 }
 
-function initStatistics(cards, attributeCanvas, manaCurveCanvas) {
-    calculateDiagramData(cards, attributeCanvas, manaCurveCanvas);
+function initStatistics(cards, attributeCanvas, manaCurveCanvas, mobile = false) {
+    calculateDiagramData(cards, attributeCanvas, manaCurveCanvas, mobile);
 }

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -82,6 +82,11 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
                         position: 'bottom',
                         text: 'Card attributes in %'
                     },
+                    datalabels:{
+                        formatter: function(value, context) {
+                            return value + ' %';
+                          }
+                    }
                 },
             },
             data: {
@@ -93,8 +98,7 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
                         backgroundColor: attributeStatData.map(row => row.color),
                         data: attributeStatData.map(row => row.count),
                         datalabels: {
-                            color: '#000000',
-                            title:'%'
+                            color: '#000000'
                           }
                     }
                 ]

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -154,7 +154,7 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
 function isNumeric(str) {
     if (typeof str != "string") return false;
     return !isNaN(str) &&
-        !isNaN(parseFloat(str))
+        !isNaN(parseFloat(str));
 }
 
 function initStatistics(cards, attributeCanvas, manaCurveCanvas, mobile = false) {

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -65,6 +65,11 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
                     colors: {
                         enabled: false,
                         forceOverride: true
+                    },
+                    title: {
+                        display: true,
+                        position: 'bottom',
+                        text: 'Counted card attributes'
                     }
                 },
             },
@@ -83,31 +88,41 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
     new Chart(manaCurveCanvas,
         {
             type: 'bar',
+            data: {
+                labels: manaCurveStatData.map(row => row.cost),
+                datasets: [
+                    { 
+                        borderColor: 'white',
+                        backgroundColor: '#a451c8',
+                        label: 'Cards with cost',
+                        data: manaCurveStatData.map(row => row.count)
+                    }
+                ]
+            },
             options: {
                 indexAxis: 'x',
                 plugins: {
-                    legend: {
-                        display: false
-                    },
                     tooltip: {
                         enabled: true
+                    },
+                    legend: {
+                        display: false
                     },
                     colors: {
                         enabled: false,
                         forceOverride: true
+                    },
+                    subtitle: {
+                        display: true,
+                        position: 'left',
+                        text: 'Number of Cards'
+                    },
+                    title: {
+                        display: true,
+                        position: 'bottom',
+                        text: 'Mana Value'
                     }
                 },
-            },
-            data: {
-                labels: manaCurveStatData.map(row => row.cost),
-                datasets: [
-                    {
-                        label: 'Card total',
-                        borderColor: 'white',
-                        backgroundColor: '#a451c8',
-                        data: manaCurveStatData.map(row => row.count)
-                    }
-                ]
             }
         });
 }

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -19,8 +19,9 @@ function calculateDiagramData(cardsToCalc, attributeCanvas, manaCurveCanvas) {
         { shortTerm: 'G', attribute: 'Wind', count: 0, color: "#19ef49" },
         { shortTerm: 0, attribute: 'Void', count: 0, color: "#b1b5b2" }
     ];
+    
 
-    cardsToCalc.forEach(card => {
+    cardsToCalc.forEach(card => {        
         if (card.cost !== null) {
             card.cost = [...card.cost.matchAll(attributeRegex)].map((el) => el[1]);
             let cardCost = 0;
@@ -44,7 +45,16 @@ function calculateDiagramData(cardsToCalc, attributeCanvas, manaCurveCanvas) {
         }
     });
 
+    let fullAttributeCount = attributeStatData.reduce((accumulator, currentValue) => {
+        return accumulator + currentValue.count
+      },0);
+
     attributeStatData.sort((a, b) => b.count - a.count);
+    attributeStatData.forEach((attribute) => {
+        console.log('calc');        
+        console.log(`${attribute.count} = ${attribute.count} * 100 / ${fullAttributeCount}`);
+        attribute.count = Math.round(attribute.count * 100 / (fullAttributeCount));
+    });
 
     drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCurveStatData);
 }
@@ -53,6 +63,7 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
     new Chart(attributeCanvas,
         {
             type: 'bar',
+            plugins: [ChartDataLabels],
             options: {
                 indexAxis: 'y',
                 plugins: {
@@ -69,18 +80,22 @@ function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCur
                     title: {
                         display: true,
                         position: 'bottom',
-                        text: 'Counted card attributes'
-                    }
+                        text: 'Card attributes in %'
+                    },
                 },
             },
             data: {
                 labels: attributeStatData.map(row => row.attribute),
                 datasets: [
                     {
-                        label: '',
+                        label: '%',
                         borderColor: 'white',
                         backgroundColor: attributeStatData.map(row => row.color),
-                        data: attributeStatData.map(row => row.count)
+                        data: attributeStatData.map(row => row.count),
+                        datalabels: {
+                            color: '#000000',
+                            title:'%'
+                          }
                     }
                 ]
             }

--- a/cardDatabase/static/js/view_decklist_statistics.js
+++ b/cardDatabase/static/js/view_decklist_statistics.js
@@ -1,0 +1,123 @@
+const attributeRegex = /\{(\w)\}+/g;
+
+function calculateDiagramData(cardsToCalc, attributeCanvas, manaCurveCanvas) {
+    let manaCurveThreshhold = 6;
+    manaCurveStatData = [
+        { cost: '0', count: 0 },
+        { cost: '1', count: 0 },
+        { cost: '2', count: 0 },
+        { cost: '3', count: 0 },
+        { cost: '4', count: 0 },
+        { cost: '5', count: 0 },
+        { cost: '6+', count: 0 },
+    ];
+    attributeStatData = [
+        { shortTerm: 'R', attribute: 'Fire', count: 0, color: "#ef1919" },
+        { shortTerm: 'U', attribute: 'Water', count: 0, color: "#199eef" },
+        { shortTerm: 'W', attribute: 'Light', count: 0, color: "#efea19" },
+        { shortTerm: 'B', attribute: 'Darkness', count: 0, color: "#a451c8" },
+        { shortTerm: 'G', attribute: 'Wind', count: 0, color: "#19ef49" },
+        { shortTerm: 0, attribute: 'Void', count: 0, color: "#b1b5b2" }
+    ];
+
+    cardsToCalc.forEach(card => {
+        if (card.cost !== null) {
+            card.cost = [...card.cost.matchAll(attributeRegex)].map((el) => el[1]);
+            let cardCost = 0;
+            card.cost.forEach(attribute => {
+                if (isNaN(attribute)) {
+                    cardCost++;
+                    attributeStatData[attributeStatData.findIndex((el) => el.shortTerm == attribute)].count += card.quantity;
+                }
+                else{
+                    cardCost += parseInt(attribute);
+                    attributeStatData[attributeStatData.findIndex((el) => el.shortTerm == 0)].count += card.quantity;
+                }
+            });
+
+            if(cardCost >= manaCurveThreshhold){
+                manaCurveStatData[manaCurveStatData.findIndex((el) => el.cost == manaCurveThreshhold + '+')].count += card.quantity;
+            }
+            else{
+                manaCurveStatData[manaCurveStatData.findIndex((el) => el.cost ==cardCost)].count += card.quantity;
+            }
+        }
+    });
+
+    attributeStatData.sort((a, b) => b.count - a.count);
+
+    drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCurveStatData);
+}
+
+function drawCharts(attributeCanvas, attributeStatData, manaCurveCanvas, manaCurveStatData) {
+    new Chart(attributeCanvas,
+        {
+            type: 'bar',
+            options: {
+                indexAxis: 'y',
+                plugins: {
+                    legend: {
+                        display: false
+                    },
+                    tooltip: {
+                        enabled: true
+                    },
+                    colors: {
+                        enabled: false,
+                        forceOverride: true
+                    }
+                },
+            },
+            data: {
+                labels: attributeStatData.map(row => row.attribute),
+                datasets: [
+                    {
+                        label: '',
+                        borderColor: 'white',
+                        backgroundColor: attributeStatData.map(row => row.color),
+                        data: attributeStatData.map(row => row.count)
+                    }
+                ]
+            }
+        });
+    new Chart(manaCurveCanvas,
+        {
+            type: 'bar',
+            options: {
+                indexAxis: 'x',
+                plugins: {
+                    legend: {
+                        display: false
+                    },
+                    tooltip: {
+                        enabled: true
+                    },
+                    colors: {
+                        enabled: false,
+                        forceOverride: true
+                    }
+                },
+            },
+            data: {
+                labels: manaCurveStatData.map(row => row.cost),
+                datasets: [
+                    {
+                        label: 'Card total',
+                        borderColor: 'white',
+                        backgroundColor: '#a451c8',
+                        data: manaCurveStatData.map(row => row.count)
+                    }
+                ]
+            }
+        });
+}
+
+function isNumeric(str) {
+    if (typeof str != "string") return false;
+    return !isNaN(str) &&
+        !isNaN(parseFloat(str))
+}
+
+function initStatistics(cards, attributeCanvas, manaCurveCanvas) {
+    calculateDiagramData(cards, attributeCanvas, manaCurveCanvas);
+}

--- a/cardDatabase/templates/cardDatabase/html/view_decklist.html
+++ b/cardDatabase/templates/cardDatabase/html/view_decklist.html
@@ -126,24 +126,24 @@
             <h2 class="deck-stats">Deck Statistics</h2>
             <div class="attribute-dist-wrapper">
                 <h4>Attribute distribution in %</h4>
-                <canvas id="attribute-dist" class="attribute-dist-canvas"></canvas>
+                <canvas id="attribute-dist-canvas" class="attribute-dist-canvas"></canvas>
             </div>
             <br>
             <h4>Card cost distribution</h4>
             <div class="mana-curve-wrapper">
-                <canvas id="mana-curve" class="mana-curve-canvas"></canvas>
+                <canvas id="mana-curve-canvas" class="mana-curve-canvas"></canvas>
             </div>
             <script>
                 let cards = JSON.parse('{% cards_to_json cards %}');
                 const untoggledZones = ['Side Deck', 'Magic Stone Deck', 'Ruler Area'];
                 Chart.defaults.borderColor = 'gray';                
 
-                cards = cards.filter((card) => !untoggledZones.find((zone) => zone == card.zone));                
+                cards = cards.filter((card) => !untoggledZones.find((zone) => zone == card.zone));
                 
                 initStatistics(
                     cards, 
-                    document.getElementById('attribute-dist'), 
-                    document.getElementById('mana-curve')
+                    document.getElementById('attribute-dist-canvas'), 
+                    document.getElementById('mana-curve-canvas')
                 );
                 
             </script>

--- a/cardDatabase/templates/cardDatabase/html/view_decklist.html
+++ b/cardDatabase/templates/cardDatabase/html/view_decklist.html
@@ -134,6 +134,11 @@
                 <canvas id="mana-curve-canvas" class="mana-curve-canvas"></canvas>
             </div>
             <script>
+                {% if request.user_agent.is_mobile or request.user_agent.is_tablet %}
+                    const mobile = true;
+                {% else %}
+                    const mobile = false;
+                {% endif %}
                 let cards = JSON.parse('{% cards_to_json cards %}');
                 const untoggledZones = ['Side Deck', 'Magic Stone Deck', 'Ruler Area'];
                 Chart.defaults.borderColor = 'gray';                
@@ -143,7 +148,8 @@
                 initStatistics(
                     cards, 
                     document.getElementById('attribute-dist-canvas'), 
-                    document.getElementById('mana-curve-canvas')
+                    document.getElementById('mana-curve-canvas'),
+                    mobile
                 );
                 
             </script>

--- a/cardDatabase/templates/cardDatabase/html/view_decklist.html
+++ b/cardDatabase/templates/cardDatabase/html/view_decklist.html
@@ -4,7 +4,7 @@
 
 {% block css %}
     {{ block.super }}
-    <link rel="stylesheet" href="{% static 'css/view_decklist.css' %}">
+    <link rel="stylesheet" href="{% static 'css/view_decklist.css' %}">    
 {% endblock %}
 
 {% block ogtitle %}{{ decklist.name }} - Force of Wind{% endblock %}
@@ -21,6 +21,7 @@
     {{ block.super }}
     <script src="{% static 'js/view_decklist.js' %}" type="text/javascript"></script>
     <script src="{% static 'js/html2canvas/html2canvas.js' %}" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.3.1/chart.umd.js" type="text/javascript"></script>
 {% endblock %}
 
 {% block body %}
@@ -118,6 +119,96 @@
             <button type="button" id="copy-image">Copy as Image</button>
             <div id="untap-list"><textarea>{% untap_list cards %}</textarea></div>
         </div>
+        <br>
+        <h2 class="deck-stats">Deck Statistics</h2>
+        <h4>Attribute distribution</h4>
+        <div class="row">
+            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper">
+                <div class="mb-3">
+                    <img class="statistics-attribute-img" src="{% static 'img/costs/fire.png' %}">
+                </div>
+                <div class="h1 mb-0" id="coloranalysis_color_r">60%</div>
+            </div>
+            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
+                <div class="mb-3">
+                    <img class="statistics-attribute-img" src="{% static 'img/costs/wind.png' %}">
+                </div>
+                <div class="h1 mb-0" id="coloranalysis_color_g">0%</div>
+            </div>
+            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper" >
+                <div class="mb-3">
+                    <img class="statistics-attribute-img" src="{% static 'img/costs/light.png' %}">
+                </div>
+                <div class="h1 mb-0" id="coloranalysis_color_w">40%</div>
+            </div>
+            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
+                <div class="mb-3">
+                    <img class="statistics-attribute-img" src="{% static 'img/costs/water.png' %}">
+                </div>
+                <div class="h1 mb-0" id="coloranalysis_color_u">0%</div>        
+            </div>
+            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
+                <div class="mb-3">
+                    <img class="statistics-attribute-img" src="{% static 'img/costs/darkness.png' %}">
+                </div>
+                <div class="h1 mb-0" id="coloranalysis_color_b">0%</div>
+            </div>
+            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
+                <div class="mb-3">
+                    <img class="statistics-attribute-img" src="{% static 'img/costs/x.png' %}">
+                </div>
+                <div class="h1 mb-0" id="coloranalysis_color_v">0%</div>
+            </div>
+        </div>
+        <br>
+        <h4>Mana Value</h4>
+        <div class="mana-curve-wrapper">
+            <canvas id="mana-curve" class="mana-curve-canvas"></canvas>
+        </div>
+        <script>
+            const data = [
+                { attribute: '0', count: 8 },
+                { attribute: '1', count: 22 },
+                { attribute: '2', count: 10 },
+                { attribute: '3', count: 0 },
+                { attribute: '4', count: 0 },
+                { attribute: '5', count: 0 },
+                { attribute: '6+', count: 0 },
+            ];
 
+            Chart.defaults.borderColor = 'gray';
+
+            const myChart = new Chart(document.getElementById('mana-curve'),
+                    {
+                        type: 'bar',
+                        options: {
+                            indexAxis: 'y',
+                            plugins: {
+                                legend: {
+                                    display: false
+                                },
+                                tooltip: {
+                                    enabled: true
+                                },
+                                colors: {
+                                    enabled: false,
+                                    forceOverride: true
+                                }
+                            },
+                        },
+                        data: {
+                            labels: data.map(row => row.attribute),
+                            datasets: [
+                                {
+                                    label: 'Card total',
+                                    borderColor: 'white',
+                                    backgroundColor: '#351543',
+                                    data: data.map(row => row.count)
+                                }
+                            ]
+                        }
+                    });
+            myChart.borderColor = '#FFFFF';
+        </script>
     </div>
 {% endblock %}

--- a/cardDatabase/templates/cardDatabase/html/view_decklist.html
+++ b/cardDatabase/templates/cardDatabase/html/view_decklist.html
@@ -22,6 +22,7 @@
     <script src="{% static 'js/view_decklist.js' %}" type="text/javascript"></script>
     <script src="{% static 'js/html2canvas/html2canvas.js' %}" type="text/javascript"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.3.1/chart.umd.js" type="text/javascript"></script>
+    <script src="{% static 'js/view_decklist_statistics.js' %}" type="text/javascript"></script>
 {% endblock %}
 
 {% block body %}
@@ -119,96 +120,33 @@
             <button type="button" id="copy-image">Copy as Image</button>
             <div id="untap-list"><textarea>{% untap_list cards %}</textarea></div>
         </div>
-        <br>
-        <h2 class="deck-stats">Deck Statistics</h2>
-        <h4>Attribute distribution</h4>
-        <div class="row">
-            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper">
-                <div class="mb-3">
-                    <img class="statistics-attribute-img" src="{% static 'img/costs/fire.png' %}">
-                </div>
-                <div class="h1 mb-0" id="coloranalysis_color_r">60%</div>
+        {% if cards %}
+            <br>
+            <h2 class="deck-stats">Deck Statistics</h2>
+            <div class="attribute-dist-wrapper">
+                <h4>Attribute distribution</h4>
+                <canvas id="attribute-dist" class="attribute-dist-canvas"></canvas>
             </div>
-            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
-                <div class="mb-3">
-                    <img class="statistics-attribute-img" src="{% static 'img/costs/wind.png' %}">
-                </div>
-                <div class="h1 mb-0" id="coloranalysis_color_g">0%</div>
+            <br>
+            <h4>Mana Value</h4>
+            <div class="mana-curve-wrapper">
+                <canvas id="mana-curve" class="mana-curve-canvas"></canvas>
             </div>
-            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper" >
-                <div class="mb-3">
-                    <img class="statistics-attribute-img" src="{% static 'img/costs/light.png' %}">
-                </div>
-                <div class="h1 mb-0" id="coloranalysis_color_w">40%</div>
-            </div>
-            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
-                <div class="mb-3">
-                    <img class="statistics-attribute-img" src="{% static 'img/costs/water.png' %}">
-                </div>
-                <div class="h1 mb-0" id="coloranalysis_color_u">0%</div>        
-            </div>
-            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
-                <div class="mb-3">
-                    <img class="statistics-attribute-img" src="{% static 'img/costs/darkness.png' %}">
-                </div>
-                <div class="h1 mb-0" id="coloranalysis_color_b">0%</div>
-            </div>
-            <div class="col-sm-4 col-md-2 text-center mb-5 mb-md-0 attribute-wrapper-disabled" >
-                <div class="mb-3">
-                    <img class="statistics-attribute-img" src="{% static 'img/costs/x.png' %}">
-                </div>
-                <div class="h1 mb-0" id="coloranalysis_color_v">0%</div>
-            </div>
-        </div>
-        <br>
-        <h4>Mana Value</h4>
-        <div class="mana-curve-wrapper">
-            <canvas id="mana-curve" class="mana-curve-canvas"></canvas>
-        </div>
-        <script>
-            const data = [
-                { attribute: '0', count: 8 },
-                { attribute: '1', count: 22 },
-                { attribute: '2', count: 10 },
-                { attribute: '3', count: 0 },
-                { attribute: '4', count: 0 },
-                { attribute: '5', count: 0 },
-                { attribute: '6+', count: 0 },
-            ];
+            <script>
+                let cards = JSON.parse('{% cards_to_json cards %}');
+                const untoggledZones = ['Side Deck', 'Magic Stone Deck', 'Ruler Area'];
+                Chart.defaults.borderColor = 'gray';
 
-            Chart.defaults.borderColor = 'gray';
-
-            const myChart = new Chart(document.getElementById('mana-curve'),
-                    {
-                        type: 'bar',
-                        options: {
-                            indexAxis: 'y',
-                            plugins: {
-                                legend: {
-                                    display: false
-                                },
-                                tooltip: {
-                                    enabled: true
-                                },
-                                colors: {
-                                    enabled: false,
-                                    forceOverride: true
-                                }
-                            },
-                        },
-                        data: {
-                            labels: data.map(row => row.attribute),
-                            datasets: [
-                                {
-                                    label: 'Card total',
-                                    borderColor: 'white',
-                                    backgroundColor: '#351543',
-                                    data: data.map(row => row.count)
-                                }
-                            ]
-                        }
-                    });
-            myChart.borderColor = '#FFFFF';
-        </script>
+                cards = cards.filter((card) => !untoggledZones.find((zone) => zone == card.zone));                
+                
+                initStatistics(
+                    cards, 
+                    document.getElementById('attribute-dist'), 
+                    document.getElementById('mana-curve')
+                );
+                
+            </script>
+        {% endif %}
+        
     </div>
 {% endblock %}

--- a/cardDatabase/templates/cardDatabase/html/view_decklist.html
+++ b/cardDatabase/templates/cardDatabase/html/view_decklist.html
@@ -22,6 +22,7 @@
     <script src="{% static 'js/view_decklist.js' %}" type="text/javascript"></script>
     <script src="{% static 'js/html2canvas/html2canvas.js' %}" type="text/javascript"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.3.1/chart.umd.js" type="text/javascript"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2 " type="text/javascript"></script>
     <script src="{% static 'js/view_decklist_statistics.js' %}" type="text/javascript"></script>
 {% endblock %}
 
@@ -124,7 +125,7 @@
             <br>
             <h2 class="deck-stats">Deck Statistics</h2>
             <div class="attribute-dist-wrapper">
-                <h4>Attribute distribution</h4>
+                <h4>Attribute distribution in %</h4>
                 <canvas id="attribute-dist" class="attribute-dist-canvas"></canvas>
             </div>
             <br>
@@ -135,7 +136,7 @@
             <script>
                 let cards = JSON.parse('{% cards_to_json cards %}');
                 const untoggledZones = ['Side Deck', 'Magic Stone Deck', 'Ruler Area'];
-                Chart.defaults.borderColor = 'gray';
+                Chart.defaults.borderColor = 'gray';                
 
                 cards = cards.filter((card) => !untoggledZones.find((zone) => zone == card.zone));                
                 

--- a/cardDatabase/templates/cardDatabase/html/view_decklist.html
+++ b/cardDatabase/templates/cardDatabase/html/view_decklist.html
@@ -128,7 +128,7 @@
                 <canvas id="attribute-dist" class="attribute-dist-canvas"></canvas>
             </div>
             <br>
-            <h4>Mana Value</h4>
+            <h4>Card cost distribution</h4>
             <div class="mana-curve-wrapper">
                 <canvas id="mana-curve" class="mana-curve-canvas"></canvas>
             </div>

--- a/cardDatabase/templatetags/card_database_tags.py
+++ b/cardDatabase/templatetags/card_database_tags.py
@@ -216,6 +216,19 @@ def format_id_text(text):
 def dict_to_json(dict_obj):
     return mark_safe(json.dumps(ast.literal_eval(str(dict_obj))))
 
+@register.simple_tag
+def cards_to_json(cards):
+    output_cards = []
+    for card in cards:
+        simple_card = {
+            "name": card.card.name,
+            "zone" : card.zone.zone.name,
+            "cost": card.card.cost,
+            "quantity" : card.quantity
+        }
+        output_cards.append(simple_card)
+    return dict_to_json(output_cards)
+
 
 @register.simple_tag
 def colours_to_imgs(colours):

--- a/cardDatabase/templatetags/card_database_tags.py
+++ b/cardDatabase/templatetags/card_database_tags.py
@@ -221,7 +221,7 @@ def cards_to_json(cards):
     output_cards = []
     for card in cards:
         simple_card = {
-            "name": card.card.name,
+            "name": card.card.name_without_punctuation,
             "zone" : card.zone.zone.name,
             "cost": card.card.cost,
             "quantity" : card.quantity


### PR DESCRIPTION
This PR implements Deck statistics on the view-decklist page.
Statistical values are pulled direclty from the deck and will only be shown if more than 1 card are in a viable Zone.

**Non counted Zones are currently: 'Side Deck', 'Magic Stone Deck', 'Ruler Area' everything else gets added to the statistic.**

Statistic Diagram is generated by Graph.js (https://www.chartjs.org/) and the Graph.js Data Label Plugin (https://chartjs-plugin-datalabels.netlify.app/).

![image](https://github.com/Force-of-Wind/fowsim/assets/74566937/86cd4f9a-f0b1-4b52-a806-1510a1c86f9e)
