### PR TITLE
Fixed buttons from disappearing on smaller windows and darkmode

### DIFF
--- a/cardDatabase/static/css/darkmode/dark_mode_overrides.css
+++ b/cardDatabase/static/css/darkmode/dark_mode_overrides.css
@@ -259,12 +259,12 @@ img.preview-deck-card-img {
     color: white;
 }
 
-.view-in-another-tab {
+.card-preview .view-in-another-tab {
     border: 1px solid mediumpurple;
     background-color: #303134;
 }
 
-.view-in-another-tab a {
+.card-preview .view-in-another-tab a {
     color: white;
 }
 

--- a/cardDatabase/static/css/view_decklist.css
+++ b/cardDatabase/static/css/view_decklist.css
@@ -301,7 +301,7 @@ button.close.modal-close-btn {
     position: relative;
     display: block;
     margin: auto;
-    min-height: 40vh;
+    min-height: 310px;
 }
 
 .draw-testhand-actions {


### PR DESCRIPTION
Set a fixed height on draw sample hand buttons to avoid smaller windows from pushing them upwards.

Fixed style that got overwritten to still be light mode when currently in darkmode.