### PR TITLE
Fixed packs that produced errors

### DIFF
--- a/cardDatabase/static/pack_config/moa.json
+++ b/cardDatabase/static/pack_config/moa.json
@@ -32,15 +32,15 @@
     ],
     "FOIL": [
         {
-            "chance": 28,
+            "chance": 29,
             "rarity": "C"
         },
         {
-            "chance": 19,
+            "chance": 20,
             "rarity": "U"
         },
         {
-            "chance": 28,
+            "chance": 29,
             "rarity": "R"
         },
         {

--- a/cardDatabase/static/pack_config/mp01.json
+++ b/cardDatabase/static/pack_config/mp01.json
@@ -59,19 +59,19 @@
             ]
         },
         {
-            "chance": 24,
+            "chance": 23,
             "rarity": "MR"
         },
         {
-            "chance": 29,
+            "chance": 28,
             "rarity": "RR"
         },
         {
-            "chance": 9,
+            "chance": 7,
             "rarity": "XR"
         },
         {
-            "chance": 9,
+            "chance": 7,
             "rarity": "SR",
             "conditions": [
                 {


### PR DESCRIPTION
MOA and MP01 did not have correct % for the pack openings resulting in errors