### PR TITLE
Added fix to also look directly at the cardid when querying for a set when in strict mode

### DIFF
--- a/cardDatabase/views/utils/search_context.py
+++ b/cardDatabase/views/utils/search_context.py
@@ -210,6 +210,10 @@ def get_set_query(data, strict_search=False):
                 # No trailing '-' because the '-' is included in CONS
                 set_query |= Q(card_id__istartswith=also_included_set)
         set_query |= Q(card_id__istartswith=fow_set + '-')
+
+        #Search for sets directly when in strict_search mode (promos like BAB wont show otherwise)
+        if strict_search:
+            set_query |= Q(card_id=fow_set)
     return set_query
 
 


### PR DESCRIPTION
… in strict_search mode. This enables to be able to search for promos since they dont have a set code but the id is the code